### PR TITLE
Set up tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,13 @@ plugins:
 last-modified-at:
     date-format: '%d-%b-%y'
 
+defaults:
+  - scope:
+      type: tags  # select all tag pages
+    values:
+      layout: tag_page
+      permalink: tags/:tag/
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_includes/posts_list.html
+++ b/_includes/posts_list.html
@@ -1,0 +1,16 @@
+<ul class="post-list">
+    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+    {%- for post in include.posts -%}
+      <li>
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          {{ post.excerpt }}
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
+</ul>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,49 @@
+---
+layout: base
+---
+
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {{ content }}
+
+
+  <!-- TODO: pull this out into a file in '_includes' to remove dup with theme_home -->
+  {% if site.paginate %}
+    {% assign posts = paginator.posts %}
+  {% else %}
+    {% assign posts = site.posts %}
+  {% endif %}
+
+
+  {%- if posts.size > 0 -%}
+    {%- if page.list_title -%}
+      <h2 class="post-list-heading">{{ page.list_title }}</h2>
+    {%- endif -%}
+
+    {%- include posts_list.html posts=posts -%}
+
+    <!-- TODO: pull this out into a file in '_includes' to remove dup with theme_home -->
+    {% if site.paginate %}
+      <div class="pager">
+        <ul class="pagination">
+        {%- if paginator.previous_page %}
+          <li><a href="{{ paginator.previous_page_path | relative_url }}" class="previous-page">{{ paginator.previous_page }}</a></li>
+        {%- else %}
+          <li><div class="pager-edge">•</div></li>
+        {%- endif %}
+          <li><div class="current-page">{{ paginator.page }}</div></li>
+        {%- if paginator.next_page %}
+          <li><a href="{{ paginator.next_page_path | relative_url }}" class="next-page">{{ paginator.next_page }}</a></li>
+        {%- else %}
+          <li><div class="pager-edge">•</div></li>
+        {%- endif %}
+        </ul>
+      </div>
+    {%- endif %}
+
+  {%- endif -%}
+
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,47 @@
+---
+layout: base
+---
+
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {{ page.date | date: date_format }}
+      </time>
+      {%- if page.modified_date -%}
+        ~
+        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+        <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+          {{ mdate | date: date_format }}
+        </time>
+      {%- endif -%}
+      {%- if page.author -%}
+        • {% for author in page.author %}
+          <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
+            {%- if forloop.last == false %}, {% endif -%}
+        {% endfor %}
+      {%- endif -%}</p>
+
+    <span>
+        {% for tag in page.tags %}
+        {% capture tag_name %}{{ tag }}{% endcapture %}
+        <a href="/tags/{{ tag_name }}">#{{ tag_name }}</a>
+        {% endfor %}
+    </span>
+
+  </header>
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  {%- if site.disqus.shortname -%}
+    {%- include disqus_comments.html -%}
+  {%- endif -%}
+
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -1,11 +1,15 @@
+---
+layout: base
+---
+
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
 
   <body>
-
-	<h1>Categroy page</h1>
+    <h1>#{{page.path}}</h1>
+    {%- include posts_list.html posts=page.linked_docs -%}
   </body>
 
 </html>

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -8,7 +8,7 @@ layout: base
   {%- include head.html -%}
 
   <body>
-    <h1>#{{page.path}}</h1>
+    <h1><a href="/tags/{{ page.path }}">#{{page.path}}</a></h1>
     {%- include posts_list.html posts=page.linked_docs -%}
   </body>
 

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {%- include head.html -%}
+
+  <body>
+
+	<h1>Categroy page</h1>
+  </body>
+
+</html>

--- a/_layouts/theme_home.html
+++ b/_layouts/theme_home.html
@@ -22,24 +22,9 @@ layout: default
     {%- if page.list_title -%}
       <h2 class="post-list-heading">{{ page.list_title }}</h2>
     {%- endif -%}
-    <ul class="post-list">
-      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-      {%- for post in posts -%}
-        {%- if page.theme == post.theme -%}
-        <li>
-          <span class="post-meta">{{ post.date | date: date_format }}</span>
-          <h3>
-            <a class="post-link" href="{{ post.url | relative_url }}">
-              {{ post.title | escape }}
-            </a>
-          </h3>
-          {%- if site.show_excerpts -%}
-            {{ post.excerpt }}
-          {%- endif -%}
-        </li>
-        {%- endif -%}
-      {%- endfor -%}
-    </ul>
+
+    {%- assign posts_matching_theme = posts | where: "theme", page.theme -%}
+    {%- include posts_list.html posts=posts_matching_theme -%}
 
     {% if site.paginate %}
       <div class="pager">

--- a/_plugins/generateTags.rb
+++ b/_plugins/generateTags.rb
@@ -1,0 +1,47 @@
+module SamplePlugin
+  class TagPageGenerator < Jekyll::Generator
+    safe true
+
+    def generate(site)
+      site.tags.each do |tag, posts|
+        site.pages << TagPage.new(site, tag, posts)
+      end
+    end
+  end
+
+  # Subclass of `Jekyll::Page` with custom method definitions.
+  class TagPage < Jekyll::Page
+    def initialize(site, tag, posts)
+      @site = site             # the current site instance.
+      @base = site.source      # path to the source directory.
+      @dir  = tag         # the directory the page will reside in.
+
+      # All pages have the same filename, so define attributes straight away.
+      @basename = 'index'      # filename without the extension.
+      @ext      = '.html'      # the extension.
+      @name     = 'index.html' # basically @basename + @ext.
+
+      # Initialize data hash with a key pointing to all posts under current tag.
+      # This allows accessing the list in a template via `page.linked_docs`.
+      @data = {
+        'linked_docs' => posts
+      }
+
+      # Look up front matter defaults scoped to type `tags`, if given key
+      # doesn't exist in the `data` hash.
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(relative_path, :tags, key)
+      end
+    end
+
+    # Placeholders that are used in constructing page URL.
+    def url_placeholders
+      {
+        :path       => @dir,
+        :tag   => @dir,
+        :basename   => basename,
+        :output_ext => output_ext,
+      }
+    end
+  end
+end

--- a/_posts/2021-01-10-make.instead.of.describing.md
+++ b/_posts/2021-01-10-make.instead.of.describing.md
@@ -3,6 +3,7 @@ layout: post
 title: how to make instead of describing
 theme: write
 permalink: /make-instead-of-describing
+tags: hemingway kerouac
 ---
 
 Despite all my admiration and enchantment while reading Hemingway's memoir *A Moveable Feast* I couldn't help but frowning at his description of his writing mantra: "make instead of describing". Surely he's been describing all along? He says he learned from a fellow writer to "distrust adjectives". I don't know exactly what it is he learned about adjectives because he did not abandon them.

--- a/_posts/2023-01-28-choose-your-next-book.md
+++ b/_posts/2023-01-28-choose-your-next-book.md
@@ -3,6 +3,7 @@ layout: post
 title: how to choose your next book
 theme: read
 permalink: /choose-your-next-book
+tags: decision-making
 ---
 
 There is a ridiculous amount of content out there.

--- a/_posts/2023-01-28-prepare-for-death.md
+++ b/_posts/2023-01-28-prepare-for-death.md
@@ -3,6 +3,7 @@ layout: post
 title: how to prepare for death
 theme: live
 permalink: /prepare-for-death
+tags: mortality
 ---
 
 Death is coming.

--- a/_posts/2023-01-28-progress-without-planning.md
+++ b/_posts/2023-01-28-progress-without-planning.md
@@ -3,6 +3,7 @@ layout: post
 title: how to progress without planning
 theme: work
 permalink: /progress-without-planning
+tags: time-management decision-making
 ---
 
 The other day I picked a bunch of books from my library and tried to start each of them.

--- a/_posts/2023-01-28-read-deeply.md
+++ b/_posts/2023-01-28-read-deeply.md
@@ -3,6 +3,7 @@ layout: post
 title: how to read deeply
 theme: read
 permalink: /read-deeply
+tags: critical-thinking
 ---
 
 I read with haste, crazed by [the amount of content]({% post_url 2023-01-28-choose-your-next-book %}) I won't get to unless I hurry.

--- a/_posts/2023-01-28-read.md
+++ b/_posts/2023-01-28-read.md
@@ -3,6 +3,7 @@ layout: post
 title: how to read to learn
 theme: read
 permalink: /read-to-learn
+tags: learning
 ---
 
 Ever since I read [How to Talk About Books You Haven't Read](https://www.goodreads.com/book/show/1143788.How_to_Talk_About_Books_You_Haven_t_Read?ac=1&from_search=true&qid=dQGK5Adu5Y&rank=1), I've stopped trying to absorb everything I read.

--- a/_posts/2023-02-22-read-slowly.md
+++ b/_posts/2023-02-22-read-slowly.md
@@ -3,6 +3,7 @@ layout: post
 title: how to read slowly
 theme: read
 permalink: /read-slowly
+tags: learning
 ---
 
 Everyone should learn to [leave books unfinished](https://okjuan.medium.com/feeling-good-about-ditching-books-1c4633fd87f).

--- a/_posts/2023-02-22-trust-yourself.md
+++ b/_posts/2023-02-22-trust-yourself.md
@@ -3,12 +3,12 @@ layout: post
 title: how to trust yourself
 theme: live
 permalink: /trust-yourself
+tags: honesty
 ---
 
 Once, when I was a Teaching Assistant for a 3rd year Computer Science course, I had to invigilate a couple students while they took a midterm.
 For reasons deemed legitimate, they had been absent the day the exam was given.
 After time was up, one of the students started a conversation with me and mentioned he had his own cryptocurrency company.
-
 
 I thought it was impressive that he was making time for entrepreneurship.
 But when I mentioned it to my friends, they pointed out that this was just talk.

--- a/_posts/2023-02-25-come.up.with.ideas.md
+++ b/_posts/2023-02-25-come.up.with.ideas.md
@@ -3,6 +3,7 @@ layout: post
 title: how to come up with ideas
 theme: make
 permalink: /come-up-with-ideas
+tags: creativity
 ---
 
 As you will have noticed, the posts on this site are all titled "how to X", but are not guides as much as blog entries.
@@ -21,7 +22,7 @@ I intend to do something similar here.
 My answers to questions of "how to" will not be answers but responses, responses meant to be in conversation with one another, regardless of whether they agree.
 
 A third inspiration is Andy Matuschak's [Evergreen Notes](https://notes.andymatuschak.org/z4SDCZQeRo4xFEQ8H4qrSqd68ucpgE6LU155C) and the underlying [Zettelkasten method](https://notes.andymatuschak.org/z2QvtE9w5zs49x7WUeG8Ut1vywHDLiG2Wkm9p).
-Instead of burying old posts beneath a mound of new ones, I want to extend an existing body of ideas continually.
+Instead of burying old posts beneath a mound of new ones, I want to extend a body of ideas continuously.
 When I look back at old journal entries I am often surprised at what I read.
 Even in a network built from personal writings you can create a world worth exploring and revisiting.
 Old ideas are transformed by new ones and the new built up from the old.

--- a/_posts/2023-03-09-justify-writing.md
+++ b/_posts/2023-03-09-justify-writing.md
@@ -3,6 +3,7 @@ layout: post
 title: how to justify writing
 theme: write
 permalink: /justify-writing
+tags: mediums
 ---
 
 Writing [The Virtual Book](https://okjuan.medium.com/the-virtual-book-part-1-782ccd4cc360) forced me to ask: when _is_ writing the best medium?

--- a/_posts/2023-03-22-live-in-the-moment.md
+++ b/_posts/2023-03-22-live-in-the-moment.md
@@ -3,6 +3,7 @@ layout: post
 title: how to live in the moment
 theme: live
 permalink: /live-in-the-moment
+tags: time-management mortality
 ---
 
 It is old advice to live now because now is the only time you will ever live.

--- a/_posts/2023-04-05-motivate-yourself.md
+++ b/_posts/2023-04-05-motivate-yourself.md
@@ -3,6 +3,7 @@ layout: post
 title: how to motivate yourself
 theme: work
 permalink: /motivate-yourself
+tags: psychology
 ---
 
 The idea is that, through sheer thought, you can mobilize a body sapped of motivation.

--- a/_posts/2023-04-10-come-up-with-ideas-2.md
+++ b/_posts/2023-04-10-come-up-with-ideas-2.md
@@ -3,6 +3,7 @@ layout: post
 title: how to come up with ideas (2)
 theme: make
 permalink: /come-up-with-ideas-2
+tags: creativity memory
 ---
 
 I find it surprisingly easy to whistle a new tune.


### PR DESCRIPTION
## TL;DR

Implemented tags using a [Jekyll Generator](https://jekyllrb.com/docs/plugins/generators/). Going forward, all I have to do is add `tags` to the front matter of posts. A page for each tag is automatically created. Posts get added to each of its tag pages automatically.

### Before
![Screenshot 2023-05-08 at 2 00 40 PM](https://user-images.githubusercontent.com/13096220/236934145-1cf7d38d-2e52-4789-b52c-38612f934c92.png)

### After
![Screenshot 2023-05-08 at 2 00 30 PM](https://user-images.githubusercontent.com/13096220/236934211-e75a5230-ba3a-46ca-af96-9a394377565a.png)

![Screenshot 2023-05-08 at 2 00 10 PM](https://user-images.githubusercontent.com/13096220/236934188-0de18f46-7983-4963-ada6-cb2ae6d613fe.png)

## Background

I learned about tags here: <https://jekyllrb.com/docs/posts> -- they seem the perfect thing. Turned out to be tricky to onboard, though:

- <https://github.com/pattex/jekyll-tagging> doesn't work because Github Pages supports a [small subset](https://pages.github.com/versions/) of plugins and versions
  - (Now I realize why the `jekyll-last-modified-at` plugin didn't work for me!)
- the alternative solutions I found on the internet -- like this one :<https://longqian.me/2017/02/09/github-jekyll-tag/> -- require a manual step for generating the tag pages
- Turns out there is a way to get custom jekyll plugins to work: <https://github.com/marketplace/actions/jekyll-deploy-action>

Had to [set up a custom Jekyll Deploy Action](https://github.com/okjuan/okjuan.github.io/commit/e6b81e13ef8b51157a228fcd0406129245d97536) and create the empty `gh-pages` to be targeted by it.

## Follow-ups

Follow up: [Implement `/tags/` page](https://github.com/okjuan/vbook/issues/1)