### PR TITLE
Tweak title of tag page

### DIFF
--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -8,7 +8,7 @@ layout: base
   {%- include head.html -%}
 
   <body>
-    <h1><a href="/tags/{{ page.path }}">#{{page.path}}</a></h1>
+    <h1><a href="/tags/{{ page.tag }}">#{{page.tag}}</a></h1>
     {%- include posts_list.html posts=page.linked_docs -%}
   </body>
 

--- a/_plugins/generateTags.rb
+++ b/_plugins/generateTags.rb
@@ -24,7 +24,8 @@ module SamplePlugin
       # Initialize data hash with a key pointing to all posts under current tag.
       # This allows accessing the list in a template via `page.linked_docs`.
       @data = {
-        'linked_docs' => posts
+        'linked_docs' => posts,
+        'tag' => tag
       }
 
       # Look up front matter defaults scoped to type `tags`, if given key


### PR DESCRIPTION
I was seeing `#creativity/index.html` instead of `#creativity` as the title of the `/tags/creativity/` page (locally only because the tag pages aren't being generated for the published website yet.) This is because I was using `page.path`. Fixing by passing in and using `page.tag`.